### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,6 @@ Or via your Maven POM:
 </dependency>
 ```
 
-## Prerequisites
-
-To retrieve content from a Kentico Cloud project via the Delivery API, you first need to activate the API for the project. See our documentation on how you can [activate the Delivery API](https://developer.kenticocloud.com/docs/using-delivery-api#section-enabling-the-delivery-api-for-your-projects).
-
 ## Using the DeliveryClient
 
 The `DeliveryClient` class is the main class of the SDK. Using this class, you can retrieve content from your Kentico Cloud projects.


### PR DESCRIPTION
Removing the whole Prerequisites section because the Delivery API is now activated by default for all projects.